### PR TITLE
Esimerkki selectin valinnan käyttämisestä uuden tiedon hakemiseen

### DIFF
--- a/forestis/src/App.js
+++ b/forestis/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Axios from 'axios';
 //includes
 import 'bootstrap/dist/css/bootstrap.min.css';
 //components
@@ -11,14 +12,38 @@ import './Assets/css/default.min.css';
 
 class App extends Component {
 
- /* constructor(props)
+  constructor(props)
   {
     super(props);
 
+    // Tilaa ylläpidetään tässä app.js juurikomponentissa ja sitten välitetään tiedot propsien kautta lapsikomponenteille, kts. render metodi
     this.state = {
-      view: "tasks"
+      regionLevels: [],
+      regions: []  
     };
-  } */
+
+    this.selectRegionLevel = this.selectRegionLevel.bind(this);
+  } 
+
+  componentDidMount() {
+    
+  // Haetaan aluetason tiedot
+  Axios.get('http://melatupa.azurewebsites.net/regionLevels')
+    .then(response => { 
+        console.log(response)    
+        this.setState({ regionLevels: response.data });
+        // Ensimmäisellä kerralla valitaan automaattisesti ensimmäinen aluetaso, jolle haetaan alue
+        this.selectRegionLevel(response.data[0].id);
+    });
+  }
+
+  selectRegionLevel(regionLevelId)
+  {
+    Axios.get('http://melatupa.azurewebsites.net/regionLevels/' + regionLevelId + '/regions')
+    .then(response => {             
+        this.setState({ regions: response.data });
+    })
+  }
 
   render() {
 
@@ -35,7 +60,9 @@ class App extends Component {
           </div>
 
           <div className="row">
-                <Scenarios/>
+                <Scenarios regionLevels={this.state.regionLevels}
+                           regions={this.state.regions}
+                           selectRegionLevel={this.selectRegionLevel} />
                 <Indicators/>
                 <Chart/>
           </div>

--- a/forestis/src/components/Scenarios.js
+++ b/forestis/src/components/Scenarios.js
@@ -1,86 +1,32 @@
 import React, { Component } from 'react'
-import Axios from 'axios';
 
 class Scenarios extends Component {
 
-    constructor(props){
+    constructor(props)
+    {
         super(props);
-
-        this.state = {
-            regionlevels: [],
-            regions1: [],
-            regions2: []
-        };
-        this.ChosenOption = this.ChosenOption.bind(this);
+        this.regionLevelSelectChange = this.regionLevelSelectChange.bind(this);
     }
 
-    componentDidMount() {
-
-        //tilan kautta
-        Axios.get('http://melatupa.azurewebsites.net/regionLevels')
-            .then(response => { 
-                console.log(response)
-            
-                this.setState({ regionlevels: response.data });
-            }),
-            Axios.get('http://melatupa.azurewebsites.net/regionLevels/1/regions')
-            .then(response => { 
-                console.log(response)
-            
-                this.setState({ regions1: response.data });
-            }),
-             Axios.get('http://melatupa.azurewebsites.net/regionLevels/2/regions')
-            .then(response => { 
-                console.log(response)
-            
-                this.setState({ regions2: response.data })
-            });
-
-    }
-    
     ChosenOption(e){
         this.setState({ ChosenOption: e.target.value })
     }
 
+    regionLevelSelectChange(event)
+    {        
+        this.props.selectRegionLevel(event.target.value);
+    }
 
     render () {
         
-        const { regionlevels } = this.props;
+        const { regionLevels,
+                regions } = this.props;
 
-        let regions = this.state.regionlevels;
+/*        let regions = this.state.regionlevels;
         var alue1 = this.state.regions1;
-        var alue2 = this.state.regions2;
-
-        return (
-            <scenarios>
-            <div className="scenarios">
-                <div className="skenaariot">
-                <div>Skenaariot</div>
-                </div>
-
-                <div className="aluetaso">
-                <div> Alue</div>
-                </div>
-
-                <div className="alue">
-                <div>Alue</div>
-                </div>
-
-                <div className="skenaariokokoelma">
-                <div>Skenaariokokoelma</div>
-                </div>
-            </div>
-
-
-            <div className="select1">
-                <select>
-                    {
-                    regions.map( e => <option key={ e.id }>{ e.name }</option>)
-                    }
-                </select>
-            </div>
-
-            <div className="select2">
+        var alue2 = this.state.regions2;*/
+        /*
+        <div className="select2">
                 <select onChange={this.ChosenOption.bind(this)}>
                     {
                     regions.map( e => {
@@ -92,8 +38,47 @@ class Scenarios extends Component {
                     }
                 </select>
             </div>
+        */
+        return (
+            <div>
+                <div className="scenarios">
+                    <div className="">
+                        <div>Aluetaso</div>
+                        <div className="select1">
+                            <select onChange={this.regionLevelSelectChange} >
+                                {
+                                    regionLevels.map( e => <option key={ e.id } value={e.id}>{ e.name }</option>)
+                                }
+                            </select>
+                        </div>
+                    </div>
 
-            </scenarios> 
+                    <div className="">
+                        <div>Alue</div>
+                        <div>
+                            <select>
+                                {
+                                    regions.map( e => <option key={ e.id }>{ e.name }</option>)
+                                }
+                            </select>
+                        </div>
+                    </div>
+
+                    <div className="">
+                        <div>Skenaariokokoelma</div>
+                    </div>
+
+                    <div className="">
+                        <div>Skenaario</div>
+                    </div>
+                </div>
+
+
+                
+
+            
+
+            </div> 
         )
     }
 }


### PR DESCRIPTION
Tässä on esimerkki miten selectistä otetaan valinta ja käytetään sitä uuden tiedon hakemiseen rajapinnasta. 
Keskeisin ero on tilan siirtäminen scenarios komponenetista app -juurikomponenttiin ja datan välittäminen propseina skenaario -komponentille. 
Huomaa myös miten seuraava haku rajapintaan tehdään valinnan seurauksena. 